### PR TITLE
Bump the VERSION Dependabot cannot write.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,13 @@ updates:
     labels:
       - "dependencies"
       - "python"
+    # constraints.txt is a resolved tree, not a manifest, but the pip ecosystem reads it as one and
+    # floats every line in it to the newest release. poetry pins poetry-core exactly (poetry 2.4.1
+    # requires poetry-core==2.4.0), so a floated line there opens a pull request that can never
+    # build. That line moves when a pin in requirements.txt moves, and the header of constraints.txt
+    # says how to regenerate the tree around it.
+    ignore:
+      - dependency-name: "poetry-core"
     groups:
       python:
         patterns:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,15 +35,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          mapfile -t units < <(
-            git diff --name-only "${BASE_SHA}" "${HEAD_SHA}" -- 'images/*/*/**' \
-              | awk -F/ 'NF >= 4 {print $1"/"$2"/"$3}' \
-              | sort -u
-          )
+          mapfile -t units < <(./scripts/changed-build-units.sh "${BASE_SHA}" "${HEAD_SHA}")
 
           failed=0
           for unit in "${units[@]:-}"; do
-            [[ -n "${unit}" && -f "${unit}/VERSION" ]] || continue
+            [[ -n "${unit}" ]] || continue
 
             if [[ -z "$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}" -- "${unit}/VERSION")" ]]; then
               echo "::error file=${unit}/VERSION::${unit} changed but ${unit}/VERSION was not bumped. Version tags are immutable."

--- a/.github/workflows/dependabot-version-bump.yml
+++ b/.github/workflows/dependabot-version-bump.yml
@@ -1,0 +1,85 @@
+name: Dependabot version bump
+
+on:
+  pull_request_target:
+    branches: [ main ]
+    paths:
+      - 'images/*/*/**'
+
+concurrency:
+  group: dependabot-version-bump-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  bump:
+    name: Bump every touched build unit
+    # Dependabot writes no VERSION, so every update it opens against a build unit trips the version
+    # guard. This closes that gap without weakening the guard, which still runs unchanged for
+    # everyone. pull_request_target is what makes it possible: a workflow Dependabot triggers through
+    # pull_request gets a read-only token and no secrets, so it could never push the bump back.
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require the token that re-runs the gate after the bump
+        env:
+          VERSION_BUMP_TOKEN: ${{ secrets.VERSION_BUMP_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          [[ -n "${VERSION_BUMP_TOKEN}" ]] || {
+            echo "::error::VERSION_BUMP_TOKEN is unset. It needs contents: write on this repository."
+            exit 1
+          }
+
+      # The base branch, for the scripts this job runs. Everything it executes comes from what is
+      # already merged, never from the pull request, so a branch can never hand a write token
+      # something of its own to run.
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      # The pull request branch, for the files this job edits. Dependabot pushes into this
+      # repository, so this is not a fork checkout, and nothing in it is executed.
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          path: head
+          fetch-depth: 0
+          # A push made with GITHUB_TOKEN fires no event, so CI would keep reporting against the
+          # pre-bump commit and the guard would stay red. A token of its own is what re-runs the
+          # gate against what actually merges.
+          token: ${{ secrets.VERSION_BUMP_TOKEN }}
+
+      - name: Bump the VERSION of every touched build unit
+        working-directory: head
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t units < <(../base/scripts/changed-build-units.sh "${BASE_SHA}" HEAD)
+
+          bumped=0
+          for unit in "${units[@]:-}"; do
+            [[ -n "${unit}" ]] || continue
+            [[ -z "$(git diff --name-only "${BASE_SHA}" HEAD -- "${unit}/VERSION")" ]] || continue
+
+            ../base/scripts/bump-build-unit.sh "${unit}" > /dev/null
+            bumped=1
+          done
+
+          [[ "${bumped}" -eq 1 ]] || {
+            echo "every touched build unit already carries its bump"
+            exit 0
+          }
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit --all --message 'build: Bump the VERSION of every build unit this update touches.'
+          git push origin "HEAD:${HEAD_REF}"

--- a/README.md
+++ b/README.md
@@ -228,6 +228,13 @@ touches a build unit without bumping its `VERSION`. The publishing job itself do
 straight to `main` republishes whatever tag the build units name, overwriting a tag that is already out there. Route
 changes through a pull request and the guard catches the missing bump before it reaches the registry.
 
+Dependabot writes no `VERSION`, so an update it opens against a build unit would fail that guard every time. The
+`Dependabot version bump` workflow closes the gap instead of weakening the guard: it moves the number and every tag the
+family README names in one commit on the Dependabot branch, and the guard then reads a pull request that already carries
+its bump. It runs on `pull_request_target`, the one event that still hands a Dependabot run a writable token, and pushes
+with a `VERSION_BUMP_TOKEN` repository secret holding `contents: write`, because a push made with the default token
+fires no event and would leave the gate reporting against the pre-bump commit.
+
 A family that carries a finding it cannot fix locally publishes an OpenVEX analysis as a cosign attestation next to
 every image, versioned at `vex/<family>.openvex.json`. It states per CVE whether the image is genuinely affected, and
 `affected` statements are reported rather than silenced: the risk is disclosed, not hidden. Whether the local gate stops

--- a/scripts/bump-build-unit.sh
+++ b/scripts/bump-build-unit.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# bump-build-unit.sh: Advances the patch version of a build unit and moves its documented tags with it.
+#
+# A version bump is never one file. VERSION carries the number, and the family README names the full
+# tag in a table, in a fenced Dockerfile snippet and inside shell commands, all of which the lint
+# stage compares against the unit. Missing one of them is exactly what the documentation check exists
+# to catch, so an automated bump makes the same edit that check demands.
+#
+# A tag is found by the version at its end rather than by a list of target names. The vocabulary of
+# published targets already lives in discover-images.sh and in check-documentation.sh, and a third
+# copy here would be one more place for it to drift.
+#
+# Usage: bump-build-unit.sh <build unit>
+#
+# Arguments:
+#   build unit  Path of the unit to bump, images/<family>/<upstream-minor>.
+
+report() {
+    local message="${1:?Usage: report <message>}"
+
+    echo "[bump] ${message}" >&2
+}
+
+next_version() {
+    local current="${1:?Usage: next_version <version>}"
+    local major minor patch
+
+    IFS=. read -r major minor patch <<< "${current}"
+
+    printf '%s.%s.%s' "${major}" "${minor}" "$((patch + 1))"
+}
+
+retag_readme() {
+    local readme="${1:?Usage: retag_readme <readme> <upstream-minor> <current> <next>}"
+    local upstream_minor="${2:?Usage: retag_readme <readme> <upstream-minor> <current> <next>}"
+    local current="${3:?Usage: retag_readme <readme> <upstream-minor> <current> <next>}"
+    local next="${4:?Usage: retag_readme <readme> <upstream-minor> <current> <next>}"
+
+    [[ -f "${readme}" ]] || return 0
+
+    sed -E -i \
+        "s/(${upstream_minor//./\\.}-[a-z-]+)-${current//./\\.}/\1-${next}/g" \
+        "${readme}"
+}
+
+main() {
+    local unit="${1:?Usage: bump-build-unit.sh <build unit>}"
+    local current next family upstream_minor
+
+    [[ -f "${unit}/VERSION" ]] || {
+        report "${unit} is not a build unit, it carries no VERSION"
+        exit 1
+    }
+
+    current="$(tr -d '[:space:]' < "${unit}/VERSION")"
+    next="$(next_version "${current}")"
+    family="$(basename "$(dirname "${unit}")")"
+    upstream_minor="$(basename "${unit}")"
+
+    printf '%s\n' "${next}" > "${unit}/VERSION"
+    retag_readme "images/${family}/README.md" "${upstream_minor}" "${current}" "${next}"
+
+    report "${unit} moved from ${current} to ${next}"
+    echo "${next}"
+}
+
+main "$@"

--- a/scripts/changed-build-units.sh
+++ b/scripts/changed-build-units.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# changed-build-units.sh: Prints every build unit a commit range touches, one path per line.
+#
+# A build unit is a directory images/<family>/<upstream-minor>/ carrying a VERSION file. A path deep
+# enough to look like one but holding no VERSION file is not a build unit and is left out, so every
+# line a caller reads is something with a version to check or to move. This is the single source both
+# the version guard and the automated bump read, so the two never disagree about what changed.
+#
+# Usage: changed-build-units.sh <base-sha> <head-sha>
+#
+# Arguments:
+#   base-sha  The commit the range starts at, exclusive.
+#   head-sha  The commit the range ends at, inclusive.
+
+readonly UNIT_PATHSPEC="images/*/*/**"
+
+changed_paths() {
+    local base="${1:?Usage: changed_paths <base-sha> <head-sha>}"
+    local head="${2:?Usage: changed_paths <base-sha> <head-sha>}"
+
+    git diff --name-only "${base}" "${head}" -- "${UNIT_PATHSPEC}" \
+        | awk -F/ 'NF >= 4 {print $1"/"$2"/"$3}' \
+        | sort -u
+}
+
+main() {
+    local base="${1:?Usage: changed-build-units.sh <base-sha> <head-sha>}"
+    local head="${2:?Usage: changed-build-units.sh <base-sha> <head-sha>}"
+    local unit
+
+    while read -r unit; do
+        [[ -f "${unit}/VERSION" ]] || continue
+
+        echo "${unit}"
+    done < <(changed_paths "${base}" "${head}")
+}
+
+main "$@"


### PR DESCRIPTION
Dependabot writes no `VERSION`, so its first pull request against a build unit tripped the version
guard, and every later one would have too. The guard stays exactly as it is. What changes is that the
bump now lands on the Dependabot branch before the guard reads it.

## What is here

| File | Why |
| --- | --- |
| `.github/workflows/dependabot-version-bump.yml` | Pushes the bump onto a Dependabot branch. Gated on `github.actor == 'dependabot[bot]'`. |
| `scripts/bump-build-unit.sh` | Moves a unit's `VERSION` and every tag its family README names, in one edit. |
| `scripts/changed-build-units.sh` | Touched-unit discovery, read by the guard and by the bump, so the two cannot drift. |
| `.github/workflows/ci.yml` | The guard now calls that shared script instead of restating the pipeline. |
| `.github/dependabot.yml` | Ignores `poetry-core`. |
| `README.md` | Documents the workflow and the secret it needs. |

## Why `pull_request_target`

A workflow Dependabot triggers through `pull_request` gets a read-only token and no repository
secrets, so it can never push anything back. `pull_request_target` is exempt from that restriction
unless the pull request's base ref was itself created by Dependabot, which `main` is not.

The push uses a `VERSION_BUMP_TOKEN` secret rather than `GITHUB_TOKEN`. A push made with the default
token fires no event, so CI would keep reporting against the pre-bump commit and the guard would stay
red on a branch that already carries its bump.

The job checks the repository out twice. Scripts run from the base branch, files are edited in the
head branch. Nothing from a pull request is ever executed with a write token.

## Why `poetry-core` is ignored

`constraints.txt` is a resolved tree, but the pip ecosystem reads it as a manifest of its own and
floats every line to the newest release. `poetry 2.4.1` requires `poetry-core==2.4.0` exactly, so a
floated line there opens a pull request that can never build. That is what broke #46.

## Verification

- `make lint` passes. Both scripts are picked up by the shebang discovery and are ShellCheck clean.
- The bump was simulated against the real Dependabot commit `3acf8e4` in a throwaway clone: it moved
  the unit to `1.0.1`, retagged the README, and the guard then passed against the result.
- A second run on the same branch is a no-op, so the push cannot loop.

## Before merging

Create a `VERSION_BUMP_TOKEN` repository secret holding a fine-grained token with `contents: write`
on this repository. Without it the job fails on its first step with an explicit message rather than
failing obscurely at checkout.